### PR TITLE
update license entry into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "algoliasearch": "^4.5.1",
     "autocomplete.js": "^0.37.1",


### PR DESCRIPTION
According to the [`LICENSE.md`](https://github.com/CleverCloud/hugo-cc-doc-theme/blob/master/LICENSE.md) (MIT) distributed here, I think it could be reflected into the `package.json` file.

Replaced `ISC` by `MIT`.

Hope you'll find this useful.