### PR TITLE
Search: replace the URL to match current location

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -36,7 +36,15 @@ var index = client.initIndex('{{ .Site.Params.algolia_indexName }}');
       }
     }
   ]).on('autocomplete:selected', function(event, suggestion, dataset, context) {
-    window.location = suggestion.href;
+    const suggestionHref = new URL(suggestion.href);
+    const hostname = window.location.hostname;
+    suggestionHref.protocol = window.location.protocol;
+    suggestionHref.hostname = window.location.hostname;
+    suggestionHref.port = window.location.port;
+    {{ if .Site.IsServer }}
+      suggestionHref.pathname = suggestionHref.pathname.replace(/^\/doc/, '');
+    {{ end }}
+    window.location = suggestionHref.href;
   });
 
 let params = (new URL(document.location)).searchParams;


### PR DESCRIPTION
The algolia items are stored using the production documentation. For
development, this is quite a pain because we can't use the search
otherwise it will redirect us to the production documentation.

Instead, we replace the suggestion href domain / port / protocol with
our current location domain / port / protocol. And if we are on
localhost (naive detection), then we strip the `/doc` part.

This may also be useful for previews if we ever have preview applications?

Let me know what you think about this.