### PR TITLE
Add comments from utterances

### DIFF
--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -26,6 +26,7 @@ ignorefiles = [ "somethingToIgnore.md"]
 	Subdir= true
 	disableSearch = false # default is false
 	disableReadmoreNav = false # set true to hide prev/next navigation, default is false
+	disableComments = false # set true to hive comments, default is false
 	highlightClihighlightClientSideentSide = false # set true to use highlight.pack.js instead of the default hugo chroma highlighter
 	menushortcutsnewtab = true # set true to open shortcuts links to a new tab/window
 	algolia_appId="algoliaAppId"

--- a/exampleSite/content/configuration/_index.md
+++ b/exampleSite/content/configuration/_index.md
@@ -40,4 +40,8 @@ In <code>config.toml</code> or a page's <code>frontmatter</code>, set <code>disa
 
 ## Search
 
-Disable search by setting <code>disableSearch = true</code> in <code>config.toml</code>. 
+Disable search by setting <code>disableSearch = true</code> in <code>config.toml</code>.
+
+## Comments
+
+Disable comments by setting <code>disableComments = true</code> in <code>config.toml</code>. 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,6 +37,14 @@
                         {{- end -}}
                     </div> 
 
+                    <div>
+                      {{ if and (ne .Site.Params.disableComments true) (ne .Params.disableComments true) }}
+                        <div class="position-relative mx-auto col-lg-9">
+                          {{ partial "comments.html" . }}
+                        </div>
+                      {{ end }}
+                    </div>
+
                 </div>
 
             </div> 

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,0 +1,10 @@
+<div class=" overflow-hidden p-3 mt-5 shadow next-prev-page">
+    <h4 id="comments" class="text-center" style="margin-top: 1.3rem;">Comments</h4>
+    <script src="https://utteranc.es/client.js"
+        repo="{{ .Site.Params.commentsRepository }}"
+        issue-term="{{ .Site.Params.commentsIssueTerm }}"
+        theme="preferred-color-scheme"
+        crossorigin="anonymous"
+        async>
+    </script>
+</div>

--- a/layouts/partials/next-prev-page.html
+++ b/layouts/partials/next-prev-page.html
@@ -1,6 +1,6 @@
 <div class=" overflow-hidden p-3 mt-5 shadow next-prev-page">
 
-    <h4 class="text-center">Read more</h4>
+    <h4 id="readmore" class="text-center" style="margin-top: 1.3rem;">Read more</h4>
 
     <!-- Next prev page -->
     {{- $currentNode := . -}}
@@ -47,9 +47,9 @@
             </a>
         {{- end }}
     </div>
-    <div class="d-flex justify-content-center">
-        <a class="p-1 mr-3 d-inline-block " href="{{ .Site.Params.contentRepository }}edit/master/{{.Page.File.Path}}">
-            {{- partial "svg.html"  (dict "id" "github" "class" "icon" "width" 32 "height" 32) -}}
+    <div class="d-flex mt-3 mb-3 justify-content-center">
+        <a class="p-1 d-inline-block " href="{{ .Site.Params.contentRepository }}edit/master/{{.Page.File.Path}}">
+            {{- partial "svg.html"  (dict "id" "github" "class" "icon mr-1" "width" 32 "height" 32) -}}
             Fork this page</a>
     </div>
 </div>

--- a/layouts/partials/tableofcontents.html
+++ b/layouts/partials/tableofcontents.html
@@ -2,4 +2,13 @@
 	<div id="ToC" class="aside__bg">
 		<h3>On this page</h3>
 	</div>
+
+	<div id="Extra" class="aside__bg" style="margin-top: 2rem;">
+		<nav id="TableOfContents">
+			<ul>
+				<li><a href="#readmore">Read more</a></li>
+				<li><a href="#comments">Comments</a></li>
+			</ul>
+		</nav>
+	</div>
 </div>


### PR DESCRIPTION
This PR adds:

- A comment block powered by utteranc.es at the bottom of the page
- A extra block in the table of contents to go to comments

It is fully configurable:
- You can disable it from frontMatter with `disableComments` params
- Update settings with `commentsRepository` and `commentsIssueTerm`

Here is an example of how to looks:

![Screenshot from 2021-05-27 13-36-15](https://user-images.githubusercontent.com/498465/119819365-94a1eb00-bef0-11eb-9b3e-2cbb2a2a71bc.png)

You can find comments as issues in this repository: https://github.com/CleverCloud/doc.clever-cloud.com-comments
